### PR TITLE
Add module dependency

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,8 @@
     Provides intergration with <a href="https://circleci.com">CircleCI</a>.
     ]]></description>
 
+    <depends>com.intellij.modules.platform</depends>
+
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.circleci.CircleCISettings"/>
         <toolWindow id="CircleCI" icon="/icons/toolbox_logo.svg" anchor="right"


### PR DESCRIPTION
This is needed so compatibility with other IDEs can be established.

https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html#modules-available-in-all-products