### PR TITLE
Fix NPE on open running workflow when there is no build

### DIFF
--- a/src/main/java/com/circleci/actions/OpenWorkflow.java
+++ b/src/main/java/com/circleci/actions/OpenWorkflow.java
@@ -19,7 +19,7 @@ public class OpenWorkflow extends AnAction {
     @Override
     public void update(@NotNull AnActionEvent event) {
         Build build = event.getDataContext().getData(CircleCIDataKeys.listSelectedBuildKey);
-        if (build.getWorkflows() != null) {
+        if (build != null && build.getWorkflows() != null) {
             event.getPresentation().setEnabled(true);
         } else {
             event.getPresentation().setEnabled(false);


### PR DESCRIPTION
Fixes https://github.com/kkowalski/intellij-circleci/issues/32

```
java.lang.NullPointerException
	at com.circleci.actions.OpenWorkflow.update(OpenWorkflow.java:22)
```

Note, I have not actually tested this, but given the stacktrace, it should fix the issue. I just at least wanted to get the conversation started on here because I get this error every time I open a project.