### PR TITLE
Support all future Intellij versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ intellij {
 
     version ideaVersion
     println "Building for IntelliJ version: ${version}"
+
+    updateSinceUntilBuild = false
 }
 
 patchPluginXml {
@@ -59,8 +61,7 @@ patchPluginXml {
         <li>Build status is automatically updated on check</li>
       </ul>"""
 
-    sinceBuild customSinceBuild
-    untilBuild customUntilBuild
+    sinceBuild 203.5981 // default
 }
 
 buildPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,6 @@
 ideaVersion=2020.3
 pluginGroup=com.circleci
 pluginName=intellij-circleci
-pluginVersion=0.0.14
-
-customSinceBuild=203
-customUntilBuild=212.*
+pluginVersion=0.0.15
 
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx2048m -Dfile.encoding=UTF-8


### PR DESCRIPTION
To avoid having to do things like https://github.com/kkowalski/intellij-circleci/commit/def012853530f86f23aced1beefd50cb5b5a6c38 every time a new major version of Intellij is released, this simply removes the `until-build` requirement. Yes, this does make it susceptible to breakage if JetBrains makes some major change to how plugins work, but I think this is a smaller risk compared to having the plugin break every release how it is now.

My change is being made in the Gradle build, but this is the actual change in the resulting `build/patchedPluginXmlFiles/plugin.xml` when `patchPluginXml` is run:

```diff 
-   <idea-version since-build="203" until-build="212.*"/>
+   <idea-version since-build="203.5981"/>
```

Note, I set `since-build` to `"203.5981"` because that is the default version if nothing is set at all. By doing that along with the [`updateSinceUntilBuild = false`](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/README.md#building-properties), I was able to have the default lower bound and have no upper bound. I'm new to Intellij plugin development, so certainly could have missed something, but this seems to both be [ok](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360010590059-Why-pluginUntilBuild-is-mandatory) to do and was able to test it by running `buildPlugin` and install it successfully in the latest version of IntelliJ:

```
IntelliJ IDEA 2021.3 (Ultimate Edition)
Build #IU-213.5744.223, built on November 27, 2021

Runtime version: 11.0.13+7-b1751.19 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
macOS 11.6.1
GC: G1 Young Generation, G1 Old Generation
Memory: 2048M
Cores: 16
Non-Bundled Plugins:
    ...
    com.circleci.intellij (0.0.15)
```