### PR TITLE
Build Filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .gradle
 /build/
+
 .idea
+intellij-circleci.iml
+intellij-circleci.ipr
+intellij-circleci.iws
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/main/java/com/circleci/CircleCIEvents.java
+++ b/src/main/java/com/circleci/CircleCIEvents.java
@@ -7,7 +7,7 @@ public class CircleCIEvents {
     public static Topic<ProjectChangedListener> PROJECT_CHANGED_TOPIC = new Topic<>("CIRCLECI_PROJECT_CHANGED", ProjectChangedListener.class);
     public static Topic<SettingsUpdatedListener> SETTINGS_UPDATED_TOPIC = new Topic<>("CIRCLECI_SETTINGS_UPDATED", SettingsUpdatedListener.class);
     public static Topic<ListModelUpdatedListener> LIST_MODEL_UPDATED_TOPIC = new Topic<>("CIRCLECI_LIST_MODEL_UPDATED", ListModelUpdatedListener.class);
-    public static Topic<BranchFilterChangedListener> BRANCH_FILTER_CHANGED_TOPIC = new Topic<>("CIRCLECI_BRANCH_FILTER_CHANGED_TOPIC", BranchFilterChangedListener.class);
+    public static Topic<BuildFilterChangedListener> BUILD_FILTER_CHANGED_TOPIC = new Topic<>("CIRCLECI_BUILD_FILTER_CHANGED_TOPIC", BuildFilterChangedListener.class);
     public static Topic<NewBuildsListener> NEW_BUILDS_TOPIC = new Topic<>("CIRCLECI_NEW_DATA_AVAILABLE", NewBuildsListener.class);
 
     public interface ProjectChangedListener {
@@ -22,8 +22,8 @@ public class CircleCIEvents {
         void listUpdate();
     }
 
-    public interface BranchFilterChangedListener {
-        void branchFilterChanged();
+    public interface BuildFilterChangedListener {
+        void buildFilterChanged();
     }
 
     public interface NewBuildsListener {

--- a/src/main/java/com/circleci/CircleCIEvents.java
+++ b/src/main/java/com/circleci/CircleCIEvents.java
@@ -7,6 +7,7 @@ public class CircleCIEvents {
     public static Topic<ProjectChangedListener> PROJECT_CHANGED_TOPIC = new Topic<>("CIRCLECI_PROJECT_CHANGED", ProjectChangedListener.class);
     public static Topic<SettingsUpdatedListener> SETTINGS_UPDATED_TOPIC = new Topic<>("CIRCLECI_SETTINGS_UPDATED", SettingsUpdatedListener.class);
     public static Topic<ListModelUpdatedListener> LIST_MODEL_UPDATED_TOPIC = new Topic<>("CIRCLECI_LIST_MODEL_UPDATED", ListModelUpdatedListener.class);
+    public static Topic<BranchFilterChangedListener> BRANCH_FILTER_CHANGED_TOPIC = new Topic<>("CIRCLECI_BRANCH_FILTER_CHANGED_TOPIC", BranchFilterChangedListener.class);
     public static Topic<NewBuildsListener> NEW_BUILDS_TOPIC = new Topic<>("CIRCLECI_NEW_DATA_AVAILABLE", NewBuildsListener.class);
 
     public interface ProjectChangedListener {
@@ -19,6 +20,10 @@ public class CircleCIEvents {
 
     public interface ListModelUpdatedListener {
         void listUpdate();
+    }
+
+    public interface BranchFilterChangedListener {
+        void branchFilterChanged();
     }
 
     public interface NewBuildsListener {

--- a/src/main/java/com/circleci/CircleCIProjectSettings.java
+++ b/src/main/java/com/circleci/CircleCIProjectSettings.java
@@ -20,7 +20,7 @@ public class CircleCIProjectSettings implements PersistentStateComponent<CircleC
 
     public Project activeProject;
     public List<Project> projects = new ArrayList<>();
-    public String branchFilter = "";
+    public String buildFilter = "";
 
     @Override
     public CircleCIProjectSettings getState() {

--- a/src/main/java/com/circleci/CircleCIProjectSettings.java
+++ b/src/main/java/com/circleci/CircleCIProjectSettings.java
@@ -20,6 +20,7 @@ public class CircleCIProjectSettings implements PersistentStateComponent<CircleC
 
     public Project activeProject;
     public List<Project> projects = new ArrayList<>();
+    public String branchFilter = "";
 
     @Override
     public CircleCIProjectSettings getState() {

--- a/src/main/java/com/circleci/actions/BranchFilterTextField.java
+++ b/src/main/java/com/circleci/actions/BranchFilterTextField.java
@@ -1,0 +1,56 @@
+package com.circleci.actions;
+
+import com.circleci.CircleCIEvents;
+import com.circleci.CircleCIProjectSettings;
+import com.circleci.i18n.CircleCIBundle;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
+import com.intellij.ui.TextFieldWithHistory;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class BranchFilterTextField extends AnAction implements CustomComponentAction {
+    private final com.intellij.openapi.project.Project projectIntellij;
+
+    public BranchFilterTextField(com.intellij.openapi.project.Project projectIntellij) {
+        this.projectIntellij = projectIntellij;
+    }
+
+    @Override
+    @NotNull
+    public JComponent createCustomComponent(@NotNull Presentation presentation, @NotNull String place) {
+        CircleCIProjectSettings projectSettings = CircleCIProjectSettings.getInstance(projectIntellij);
+
+        TextFieldWithHistory field = new TextFieldWithHistory();
+        field.setText(projectSettings.branchFilter);
+        field.setToolTipText(CircleCIBundle.message("branch.filter.action"));
+        field.setMinimumAndPreferredWidth(200);
+
+        projectIntellij.getMessageBus()
+                .connect()
+                .subscribe(CircleCIEvents.PROJECT_CHANGED_TOPIC, event -> {
+                    if (event.getPrevious() != event.getCurrent()) {
+                        field.setText("");
+                    }
+                });
+
+        field.addActionListener(event -> {
+            projectSettings.branchFilter = field.getText();
+            field.addCurrentTextToHistory();
+
+            projectIntellij
+                    .getMessageBus()
+                    .syncPublisher(CircleCIEvents.BRANCH_FILTER_CHANGED_TOPIC)
+                    .branchFilterChanged();
+        });
+
+        return field;
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+    }
+}

--- a/src/main/java/com/circleci/actions/BuildFilterTextField.java
+++ b/src/main/java/com/circleci/actions/BuildFilterTextField.java
@@ -12,10 +12,10 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
-public class BranchFilterTextField extends AnAction implements CustomComponentAction {
+public class BuildFilterTextField extends AnAction implements CustomComponentAction {
     private final com.intellij.openapi.project.Project projectIntellij;
 
-    public BranchFilterTextField(com.intellij.openapi.project.Project projectIntellij) {
+    public BuildFilterTextField(com.intellij.openapi.project.Project projectIntellij) {
         this.projectIntellij = projectIntellij;
     }
 
@@ -25,8 +25,8 @@ public class BranchFilterTextField extends AnAction implements CustomComponentAc
         CircleCIProjectSettings projectSettings = CircleCIProjectSettings.getInstance(projectIntellij);
 
         TextFieldWithHistory field = new TextFieldWithHistory();
-        field.setText(projectSettings.branchFilter);
-        field.setToolTipText(CircleCIBundle.message("branch.filter.action"));
+        field.setText(projectSettings.buildFilter);
+        field.setToolTipText(CircleCIBundle.message("build.filter.action"));
         field.setMinimumAndPreferredWidth(200);
 
         projectIntellij.getMessageBus()
@@ -38,13 +38,13 @@ public class BranchFilterTextField extends AnAction implements CustomComponentAc
                 });
 
         field.addActionListener(event -> {
-            projectSettings.branchFilter = field.getText();
+            projectSettings.buildFilter = field.getText();
             field.addCurrentTextToHistory();
 
             projectIntellij
                     .getMessageBus()
-                    .syncPublisher(CircleCIEvents.BRANCH_FILTER_CHANGED_TOPIC)
-                    .branchFilterChanged();
+                    .syncPublisher(CircleCIEvents.BUILD_FILTER_CHANGED_TOPIC)
+                    .buildFilterChanged();
         });
 
         return field;

--- a/src/main/java/com/circleci/actions/BuildFilterTextField.java
+++ b/src/main/java/com/circleci/actions/BuildFilterTextField.java
@@ -29,14 +29,6 @@ public class BuildFilterTextField extends AnAction implements CustomComponentAct
         field.setToolTipText(CircleCIBundle.message("build.filter.action"));
         field.setMinimumAndPreferredWidth(200);
 
-        projectIntellij.getMessageBus()
-                .connect()
-                .subscribe(CircleCIEvents.PROJECT_CHANGED_TOPIC, event -> {
-                    if (event.getPrevious() != event.getCurrent()) {
-                        field.setText("");
-                    }
-                });
-
         field.addActionListener(event -> {
             projectSettings.buildFilter = field.getText();
             field.addCurrentTextToHistory();

--- a/src/main/java/com/circleci/api/model/Build.java
+++ b/src/main/java/com/circleci/api/model/Build.java
@@ -168,4 +168,14 @@ public class Build {
     public int hashCode() {
         return Objects.hash(buildNumber, url, vcsType, project, organization);
     }
+
+    public String getFilterableText() {
+        return new StringBuilder()
+                .append(getBranch())
+                .append(getBuildNumber())
+                .append(getSubject())
+                .append(getUser() != null ? getUser().getLogin() : "")
+                .append(getWorkflows() != null ? getWorkflows().getJobName() : "")
+                .toString();
+    }
 }

--- a/src/main/java/com/circleci/ui/CircleCIToolWindow.java
+++ b/src/main/java/com/circleci/ui/CircleCIToolWindow.java
@@ -53,11 +53,7 @@ public class CircleCIToolWindow extends SimpleToolWindowPanel implements Disposa
 
         updateLoadingPanelOnSettingsUpdated(loadingPanel);
 
-        FilteringListModel<Build> filteringListModel = new FilteringListModel<>(listModel);
-        filteringListModel.setFilter(build -> build.getBranch().contains(projectSettings.branchFilter));
-        project.getMessageBus().connect().subscribe(CircleCIEvents.BRANCH_FILTER_CHANGED_TOPIC, filteringListModel::refilter);
-
-        JBList<Build> list = new BuildList(filteringListModel);
+        JBList<Build> list = new BuildList(project, listModel);
         list.setDataProvider(dataId -> {
             if (dataId.equals(CircleCIDataKeys.listSelectedBuildKey.getName())) {
                 return list.getSelectedValue();

--- a/src/main/java/com/circleci/ui/CircleCIToolWindow.java
+++ b/src/main/java/com/circleci/ui/CircleCIToolWindow.java
@@ -1,7 +1,7 @@
 package com.circleci.ui;
 
 import com.circleci.*;
-import com.circleci.actions.BranchFilterTextField;
+import com.circleci.actions.BuildFilterTextField;
 import com.circleci.actions.CircleCIProjectComboBox;
 import com.circleci.api.model.Build;
 import com.circleci.ui.list.BuildList;
@@ -16,7 +16,6 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.*;
 import com.intellij.ui.components.JBList;
 import com.intellij.ui.components.JBLoadingPanel;
-import com.intellij.ui.speedSearch.FilteringListModel;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 
@@ -108,7 +107,7 @@ public class CircleCIToolWindow extends SimpleToolWindowPanel implements Disposa
         actionGroup.add(ActionManager.getInstance().getAction("CircleCI.Refresh"));
         actionGroup.add(ActionManager.getInstance().getAction("CircleCI.AddProject"));
         actionGroup.add(new CircleCIProjectComboBox(project));
-        actionGroup.add(new BranchFilterTextField(project));
+        actionGroup.add(new BuildFilterTextField(project));
         actionGroup.add(ActionManager.getInstance().getAction("CircleCI.OpenSettings"));
         actionGroup.addSeparator();
 

--- a/src/main/java/com/circleci/ui/list/BuildList.java
+++ b/src/main/java/com/circleci/ui/list/BuildList.java
@@ -1,22 +1,36 @@
 package com.circleci.ui.list;
 
+import com.circleci.CircleCIEvents;
+import com.circleci.CircleCIProjectSettings;
 import com.circleci.api.model.Build;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionPopupMenu;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.project.Project;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.components.JBList;
+import com.intellij.ui.speedSearch.FilteringListModel;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
 import java.awt.*;
 
 public class BuildList extends JBList<Build> {
 
-    public BuildList(@NotNull ListModel<Build> dataModel) {
+    public BuildList(@NotNull Project project, @NotNull ListModel<Build> dataModel) {
+        this(project, new FilteringListModel<>(dataModel));
+    }
+
+    private BuildList(@NotNull Project project, @NotNull FilteringListModel<Build> dataModel) {
         super(dataModel);
 
-        setEmptyText("No Builds available");
+        CircleCIProjectSettings projectSettings = CircleCIProjectSettings.getInstance(project);
+        dataModel.setFilter(build -> build.getBranch().contains(projectSettings.branchFilter));
+        project.getMessageBus().connect().subscribe(CircleCIEvents.BRANCH_FILTER_CHANGED_TOPIC, dataModel::refilter);
+        dataModel.getOriginalModel().addListDataListener(new EmptyTextSetter());
+
         setCellRenderer(new BuildListCellRenderer());
 
         ActionManager actionManager = ActionManager.getInstance();
@@ -33,4 +47,38 @@ public class BuildList extends JBList<Build> {
         addMouseListener(popupHandler);
     }
 
+    private class EmptyTextSetter implements ListDataListener {
+        EmptyTextSetter() {
+            setEmptyText();
+        }
+
+        @Override
+        public void intervalAdded(ListDataEvent e) {
+            setEmptyText();
+        }
+
+        @Override
+        public void intervalRemoved(ListDataEvent e) {
+            setEmptyText();
+        }
+
+        @Override
+        public void contentsChanged(ListDataEvent e) {
+            setEmptyText();
+        }
+
+        private void setEmptyText() {
+            String emptyText = "No builds available";
+            ListModel<Build> model = BuildList.this.getModel();
+            if (model instanceof FilteringListModel) {
+                int filteredSize = model.getSize();
+                int orgSize = ((FilteringListModel<Build>) model).getOriginalModel().getSize();
+                if (filteredSize == 0 && orgSize > 0) {
+                    BuildList.this.setEmptyText(emptyText + " (" + orgSize + " builds are filtered)");
+                    return;
+                }
+            }
+            BuildList.this.setEmptyText(emptyText);
+        }
+    }
 }

--- a/src/main/java/com/circleci/ui/list/BuildList.java
+++ b/src/main/java/com/circleci/ui/list/BuildList.java
@@ -27,8 +27,8 @@ public class BuildList extends JBList<Build> {
         super(dataModel);
 
         CircleCIProjectSettings projectSettings = CircleCIProjectSettings.getInstance(project);
-        dataModel.setFilter(build -> build.getBranch().contains(projectSettings.branchFilter));
-        project.getMessageBus().connect().subscribe(CircleCIEvents.BRANCH_FILTER_CHANGED_TOPIC, dataModel::refilter);
+        dataModel.setFilter(build -> build.getFilterableText().contains(projectSettings.buildFilter));
+        project.getMessageBus().connect().subscribe(CircleCIEvents.BUILD_FILTER_CHANGED_TOPIC, dataModel::refilter);
         dataModel.getOriginalModel().addListDataListener(new EmptyTextSetter());
 
         setCellRenderer(new BuildListCellRenderer());

--- a/src/main/resources/messages/CircleCIBundle.properties
+++ b/src/main/resources/messages/CircleCIBundle.properties
@@ -1,3 +1,4 @@
 refresh.action=Refresh
 add.project.action=Add Project
 open.settings.action=Open Settings
+branch.filter.action=Branch Filter

--- a/src/main/resources/messages/CircleCIBundle.properties
+++ b/src/main/resources/messages/CircleCIBundle.properties
@@ -1,4 +1,4 @@
 refresh.action=Refresh
 add.project.action=Add Project
 open.settings.action=Open Settings
-branch.filter.action=Branch Filter
+build.filter.action=Build Filter


### PR DESCRIPTION
This is a small feature enhancement to filter the builds list by subject, branch, user, build number, or job name. It filters client-side using a simple string concatenation of the fields listed above, so doesn't support fancy queries or any of the v2 server-side filters. The client-side filtering does mean though that it's pretty snappy and doesn't need to re-query the server each time. It is also a text field with history, so remembers the user's last 5 filters. 

![image](https://user-images.githubusercontent.com/966764/153716447-eb1c41e6-59fc-4314-886d-d7efa1cfb967.png)

This is my first time doing anything IntelliJ plugins, and I haven't touched Java in years, so I'm sure I got some things wrong, but at least it seems to work. I would also like to add some tests. As such, opening this as a draft for now, but if you're interested in this, give it a review and I can try to clean things up.